### PR TITLE
Add class listing all SSL ciphers present on a local JVM

### DIFF
--- a/src/main/java/org/java/sample/ssl/ListSSLCiphers.java
+++ b/src/main/java/org/java/sample/ssl/ListSSLCiphers.java
@@ -1,0 +1,38 @@
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.net.ssl.SSLServerSocketFactory;
+
+public class ListSSLCiphers
+{
+    // Print out avaiable Ciphers on your JRE
+    public static void main(String[] args)
+        throws Exception
+    {
+        SSLServerSocketFactory ssf = (SSLServerSocketFactory)SSLServerSocketFactory.getDefault();
+
+        String[] defaultCiphers = ssf.getDefaultCipherSuites();
+        String[] availableCiphers = ssf.getSupportedCipherSuites();
+
+        TreeMap ciphers = new TreeMap();
+
+        for(int i=0; i<availableCiphers.length; ++i )
+            ciphers.put(availableCiphers[i], Boolean.FALSE);
+
+        for(int i=0; i<defaultCiphers.length; ++i )
+            ciphers.put(defaultCiphers[i], Boolean.TRUE);
+
+        System.out.println("Default\tCipher");
+        for(Iterator i = ciphers.entrySet().iterator(); i.hasNext(); ) {
+            Map.Entry cipher=(Map.Entry)i.next();
+
+            if(Boolean.TRUE.equals(cipher.getValue()))
+                System.out.print('*');
+            else
+                System.out.print(' ');
+
+            System.out.print('\t');
+            System.out.println(cipher.getKey());
+        }
+    }
+}


### PR DESCRIPTION
This PR introduce a single class utility methods to list existing ciphers on a local JVM. 
This is marginally useful when weird SSL behavior occurs and that you start doubting what is actually behind used under the hood. 

Usually the problem is elsewhere. 